### PR TITLE
feat(auth): add token revalidation endpoint

### DIFF
--- a/src/auth/auth.controller.ts
+++ b/src/auth/auth.controller.ts
@@ -3,6 +3,7 @@ import {
   Controller,
   Get,
   Post,
+  Query,
   Request,
   UseGuards,
 } from '@nestjs/common';
@@ -32,6 +33,11 @@ export class AuthController {
     @Body() createUserDto: CreateUserDto,
   ): Promise<UserDocumentWithoutPassword> {
     return this.authService.register(createUserDto);
+  }
+
+  @Get('revalidate')
+  revalidate(@Query('token') token: string): Promise<LoginDocument> {
+    return this.authService.revalidate(token);
   }
 
   @Get('test')

--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -53,4 +53,35 @@ export class AuthService {
   ): Promise<UserDocumentWithoutPassword> {
     return await this.userService.create(createUserDto);
   }
+
+  async revalidate(token: string) {
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+    const verifyAsync = await this.jwtService.verifyAsync(token);
+
+    if (!verifyAsync) {
+      throw new HttpException('Invalid token', HttpStatus.UNAUTHORIZED);
+    }
+
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+    const decode = await this.jwtService.decode(token);
+
+    if (!decode) {
+      throw new HttpException('Invalid token', HttpStatus.UNAUTHORIZED);
+    }
+
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+    const user = await this.userService.findOne(decode.sub as ObjectId);
+
+    const payload = {
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+      sub: user.id,
+      email: user.email,
+    };
+
+    const newToken = await this.jwtService.signAsync(payload);
+    return {
+      user,
+      token: newToken,
+    };
+  }
 }


### PR DESCRIPTION
Introduce a new endpoint `/auth/revalidate` to revalidate user tokens. This allows users to refresh their session without needing to log in again, improving user experience and security by ensuring tokens remain valid.