### PR TITLE
feat(product): add admin endpoint to fetch products

### DIFF
--- a/src/product/product.controller.ts
+++ b/src/product/product.controller.ts
@@ -41,6 +41,14 @@ export class ProductController {
     return this.productService.findAll(page, limit);
   }
 
+  @Get('admin')
+  findAllAdmin(
+    @Query('page', new DefaultValuePipe(1), ParseIntPipe) page: number,
+    @Query('limit', new DefaultValuePipe(10), ParseIntPipe) limit: number,
+  ): Promise<ProductFindAllPaginate | undefined> {
+    return this.productService.findAllAdmin(page, limit);
+  }
+
   @Get(':id')
   findOne(@Param('id') id: ObjectId): Promise<ProductDocument | undefined> {
     return this.productService.findOne(id);

--- a/src/product/product.service.ts
+++ b/src/product/product.service.ts
@@ -60,6 +60,41 @@ export class ProductService {
   async findAll(
     page = 1,
     limit = 10,
+    isAvailable: boolean = true,
+  ): Promise<ProductFindAllPaginate | undefined> {
+    try {
+      const skip = (page - 1) * limit;
+      const [products, total] = await Promise.all([
+        this.productModule
+          .find({ isAvailable })
+          .populate('createdBy', ['name', 'email', 'role'])
+          .skip(skip)
+          .limit(limit)
+          .exec(),
+        this.productModule.countDocuments(),
+      ]);
+
+      return {
+        data: products,
+        meta: {
+          total,
+          page,
+          limit,
+          totalPages: Math.ceil(total / limit),
+          hasNextPage: skip + limit < total,
+          hasPrevPage: page > 1,
+        },
+      };
+    } catch (error) {
+      if (error instanceof Error) {
+        throw new HttpException(error.message, HttpStatus.NOT_FOUND);
+      }
+    }
+  }
+
+  async findAllAdmin(
+    page = 1,
+    limit = 10,
   ): Promise<ProductFindAllPaginate | undefined> {
     try {
       const skip = (page - 1) * limit;


### PR DESCRIPTION
Introduce a new endpoint `/admin` to allow fetching products with additional details for admin users. This includes modifying the service to support this new functionality while maintaining the existing behavior for non-admin users.